### PR TITLE
Support OR filtering for place tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ entity = "node"
 keys = ["name"]
 
 # Filter by tag
-# Ex: Keep places which have cuisine=ice_cream tag
+# Ex: Keep places which have (amenity=cafe OR amenity=restaurant) AND cusine=ice_cream tags
+tags.amenity = ["cafe", "restaurant"]
 tags.cuisine = "ice_cream"
 ```
 

--- a/src/diner_osm/config.py
+++ b/src/diner_osm/config.py
@@ -10,7 +10,7 @@ ENTITY_MAPPING = {"node": NODE, "way": WAY, "relation": RELATION, "area": AREA}
 class PlacesConfig:
     entity: str = ""
     keys: list[str] = field(default_factory=list)
-    tags: dict[str, str] = field(default_factory=dict)
+    tags: dict[str, str | list[str]] = field(default_factory=dict)
 
     def __post_init__(self):
         if self.entity:

--- a/src/diner_osm/prepare.py
+++ b/src/diner_osm/prepare.py
@@ -85,7 +85,11 @@ def extract_places(config: PlacesConfig, path: Path) -> GeoDataFrame:
     for key in config.keys:
         fp.with_filter(KeyFilter((key)))
     for key, value in config.tags.items():
-        fp.with_filter(TagFilter((key, value)))
+        if isinstance(value, list):
+            tags = [(key, v) for v in value]
+        else:
+            tags = [(key, value)]
+        fp.with_filter(TagFilter(*tags))
     fp.with_filter(GeoInterfaceFilter(tags=tags_to_keep)).with_filter(
         EnrichAttributes()
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,14 @@ def diner_osm_config() -> DinerOsmConfig:
                 ),
             ),
             "good-doberan": RegionConfig(
-                places=PlacesConfig(),
+                places=PlacesConfig(
+                    entity="",
+                    keys=[],
+                    tags={
+                        "amenity": ["post_office", "bank"],
+                        "operator": ["Deutsche Post", "Postbank", "Deutsche Post AG"],
+                    },
+                ),
                 clip=ClipConfig(),
                 areas=PlacesConfig(),
             ),

--- a/tests/fixtures/test.toml
+++ b/tests/fixtures/test.toml
@@ -31,4 +31,5 @@ tags.memorial = "bust"
 [good-doberan.clip]
 
 [good-doberan.places]
-
+tags.amenity = ["post_office", "bank"]
+tags.operator = ["Deutsche Post", "Postbank", "Deutsche Post AG"]

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -88,6 +88,20 @@ def test_extract_places(mocker: MockerFixture, config: PlacesConfig) -> None:
         assert gdf[gdf[tag] != value].empty
 
 
+def test_complex_tags() -> None:
+    config = PlacesConfig(
+        tags={"amenity": ["restaurant", "cafe"], "cuisine": ["german", "ice_cream"]},
+    )
+    gdf = extract_places(config=config, path=Path("tests/fixtures/test.osm.pbf"))
+
+    # Should not be empty
+    assert not gdf.empty
+
+    # Should filter tags
+    assert set(gdf["amenity"]) == set(config.tags["amenity"])
+    assert set(gdf["cuisine"]) == set(config.tags["cuisine"])
+
+
 @pytest.mark.parametrize(
     ("bbox", "tags"),
     [


### PR DESCRIPTION
Addresses https://github.com/KatieBSC/diner-osm/issues/1:

Modify `PlacesConfig.tags` to also accept a list of strings for dict values.

Example: The following would filter for places which have _either_ `amenity=post_office` OR `amenity=bank` tags, **and** also have _either_ `operator=Deutsche Post`,` operator=Postbank`, or `operator=Deutsche Post AG` tags.
```
tags.amenity = ["post_office", "bank"]
tags.operator = ["Deutsche Post", "Postbank", "Deutsche Post AG"]
```

This also applies to area filtering.
Example: The following would filter for areas with `admin_level=8` which are either administrative or place boundaries.
```
tags.admin_level = "8"
tags.boundary = ["administrative", "place"]
```

**Limitations:**
More complex conditions between different tag keys, such as either `operator=Deutsche Post AG` or `name=Postbank`, are not supported.